### PR TITLE
FreeBSD support, base_path & some fixes

### DIFF
--- a/librenms/build-base.sls
+++ b/librenms/build-base.sls
@@ -6,6 +6,7 @@ include:
 librenms_build_base:
   cmd.run:
     - cwd: {{ librenms.general.home }}
+    - user: {{ librenms.general.user }}
     - name: php {{ librenms.general.home }}/build-base.php
     - unless: "php {{ librenms.general.home }}/validate.php | grep -E '^DB Schema.*[1-9][0-9]+$'"
     - require:

--- a/librenms/build-base.sls
+++ b/librenms/build-base.sls
@@ -7,6 +7,6 @@ librenms_build_base:
   cmd.run:
     - cwd: {{ librenms.general.home }}
     - name: php {{ librenms.general.home }}/build-base.php
-    - unless: "php {{ librenms.general.home }}/validate.php | grep -E '^DB Schema.*[0-9]+$'"
+    - unless: "php {{ librenms.general.home }}/validate.php | grep -E '^DB Schema.*[1-9][0-9]+$'"
     - require:
       - file: librenms_config

--- a/librenms/build-base.sls
+++ b/librenms/build-base.sls
@@ -7,6 +7,6 @@ librenms_build_base:
   cmd.run:
     - cwd: {{ librenms.general.home }}
     - name: php {{ librenms.general.home }}/build-base.php
-    - unless: "php validate.php | grep -E '^DB Schema: [0-9]+$'"
+    - unless: "php {{ librenms.general.home }}/validate.php | grep -E '^DB Schema.*[0-9]+$'"
     - require:
       - file: librenms_config

--- a/librenms/files/config.php
+++ b/librenms/files/config.php
@@ -24,11 +24,19 @@ $config['user'] = '{{ librenms.general.user }}';
 
 ### This should *only* be set if you want to *force* a particular hostname/port
 ### It will prevent the web interface being usable form any other hostname
-{% if librenms.config.base_url is not defined -%}
+{% set base_url = '' -%}
+{%- if librenms.config.base_url is not defined -%}
 #$config['base_url']        = "http://librenms.company.com";
-{%- else -%}
-$config['base_url']        = "{{ librenms.config.base_url }}";
-{% endif %}
+{%  else -%}
+{%-   set base_url = librenms.config.base_url %}
+{%- endif %}
+{%- if librenms.config.base_path is defined -%}
+{%    set base_url = base_url + librenms.config.base_path + '/' -%}
+{%- endif %}
+{%- if base_url != '' -%}
+$config['base_url']        = "{{ base_url }}";
+{%- endif %}
+
 ### Enable this to use rrdcached. Be sure rrd_dir is within the rrdcached dir
 ### and that your web server has permission to talk to rrdcached.
 {% if librenms.config.rrdcached is not defined -%}

--- a/librenms/init.sls
+++ b/librenms/init.sls
@@ -89,3 +89,10 @@ librenms_crontab:
     - require:
       - git: librenms_git
 {% endif %}
+
+librenms_compose_install:
+  cmd.run:
+    - name: ./scripts/composer_wrapper.php install --no-dev
+    - cwd: {{ librenms.general.home }}
+    - onchanges:
+      - git: librenms_git

--- a/librenms/init.sls
+++ b/librenms/init.sls
@@ -3,14 +3,22 @@ librenms_pkgs_install:
   pkg.installed:
     - names: {{ librenms.lookup.pkgs }}
 
+librenms_directory:
+  file.directory:
+    - name: {{ librenms.general.home }}
+    - user: {{ librenms.general.user }}
+    - group: {{ librenms.general.group }}
+
 librenms_git:
   git.latest:
     - name: https://github.com/librenms/librenms.git
+    - user: {{ librenms.general.user }}
     - target: {{ librenms.general.home }}
     - force_clone: True
     - require:
       - pkg: librenms_pkgs_install
       - user: librenms_user
+      - file: librenms_directory
 
 librenms_config:
   file.managed:
@@ -41,28 +49,26 @@ librenms_user:
 librenms_log_folder:
   file.directory:
     - name: {{ librenms.general.home }}/logs
+    - user: {{ librenms.general.user }}
+    - group: {{ librenms.general.group }}
+    - recurse:
+      - user
+      - group
+    - mode: 775
     - require:
       - git: librenms_git
 
 librenms_rrd_folder:
   file.directory:
     - name: {{ librenms.general.home }}/rrd
-    - mode: 775
-    - require:
-      - git: librenms_git
-
-librenms_directory:
-  file.directory:
-    - name: {{ librenms.general.home }}
     - user: {{ librenms.general.user }}
     - group: {{ librenms.general.group }}
     - recurse:
       - user
       - group
+    - mode: 775
     - require:
       - git: librenms_git
-      - file: librenms_log_folder
-      - file: librenms_rrd_folder
 
 librenms_crontab:
   file.managed:

--- a/librenms/init.sls
+++ b/librenms/init.sls
@@ -14,6 +14,7 @@ librenms_git:
     - name: https://github.com/librenms/librenms.git
     - user: {{ librenms.general.user }}
     - target: {{ librenms.general.home }}
+    - rev: {{ librenms.get('revision', 'master') }}
     - force_checkout: True
     - force_clone: True
     - force_fetch: True

--- a/librenms/init.sls
+++ b/librenms/init.sls
@@ -79,6 +79,8 @@ librenms_user:
   group.present:
     - name: {{ librenms.general.group }}
     - system: True
+    - addusers:
+      - {{ librenms.lookup.webserver_user }}
 
 librenms_log_folder:
   file.directory:

--- a/librenms/init.sls
+++ b/librenms/init.sls
@@ -124,6 +124,7 @@ librenms_crontab:
 librenms_compose_install:
   cmd.run:
     - name: ./scripts/composer_wrapper.php install --no-dev
+    - user: {{ librenms.general.user }}
     - cwd: {{ librenms.general.home }}
     - onchanges:
       - git: librenms_git

--- a/librenms/init.sls
+++ b/librenms/init.sls
@@ -8,6 +8,9 @@ librenms_directory:
     - name: {{ librenms.general.home }}
     - user: {{ librenms.general.user }}
     - group: {{ librenms.general.group }}
+    - require:
+      - user: librenms_user
+      - group: librenms_user
 
 librenms_git:
   git.latest:

--- a/librenms/init.sls
+++ b/librenms/init.sls
@@ -71,8 +71,21 @@ librenms_rrd_folder:
       - git: librenms_git
 
 librenms_crontab:
+{% if grains['os_family'] == 'FreeBSD' %}
+{# FreeBSD has no /etc/cron.d/ and a uses slightly different format #}
+  cmd.run:
+    - name: "sed 's/  librenms    /  /g' '{{ librenms.general.home }}/librenms.nonroot.cron' > /var/cron/tabs/librenms"
+    - onchanges:
+      - git: librenms_git
+  file.managed:
+    - name: /var/cron/tabs/librenms
+    - mode: 600
+    - user: root
+    - group: wheel
+{% else %}
   file.managed:
     - name: /etc/cron.d/librenms
     - source: {{ librenms.general.home }}/librenms.nonroot.cron
     - require:
       - git: librenms_git
+{% endif %}

--- a/librenms/map.jinja
+++ b/librenms/map.jinja
@@ -24,6 +24,19 @@
             ],
             'webserver_group': 'apache',
         },
+        'FreeBSD': {
+            'pkgs': [
+                'fping',
+                'git',
+                'graphviz',
+                'ImageMagick-nox11',
+                'mtr-nox11',
+                'nmap',
+                'rrdtool',
+                'whois',
+            ],
+            'webserver_group': 'www',
+        },
     }),
     'general': {
         'user': 'librenms',

--- a/librenms/map.jinja
+++ b/librenms/map.jinja
@@ -13,6 +13,7 @@
                 'snmp',
                 'whois',
             ],
+            'webserver_user': 'www-data',
             'webserver_group': 'www-data',
         },
         'RedHat': {
@@ -29,6 +30,7 @@
                 'MySQL-python',
                 'cronie'
             ],
+            'webserver_user': 'apache',
             'webserver_group': 'apache',
         },
         'FreeBSD': {
@@ -42,6 +44,7 @@
                 'rrdtool',
                 'whois',
             ],
+            'webserver_user': 'www',
             'webserver_group': 'www',
         },
     }),

--- a/librenms/map.jinja
+++ b/librenms/map.jinja
@@ -2,9 +2,16 @@
      'lookup': salt['grains.filter_by']({
         'Debian': {
             'pkgs': [
-                'rrdtool',
                 'fping',
                 'git',
+                'graphviz',
+                'imagemagick',
+                'mtr-tiny',
+                'nmap',
+                'python-mysqldb',
+                'rrdtool',
+                'snmp',
+                'whois',
             ],
             'webserver_group': 'www-data',
         },

--- a/librenms/users.sls
+++ b/librenms/users.sls
@@ -3,13 +3,13 @@
 include:
   - librenms
 
-librenms_webusers:
+{% for user, option in librenms.config.users.items() %}
+librenms_webuser_{{ user}}:
   cmd.run:
+    - name: php adduser.php "{{ user }}" "{{ option.password }}" "{{ option.level }}" "{{ option.email }}"
     - cwd: {{ librenms.general.home }}
     - onlyif: "php {{ librenms.general.home }}/validate.php | grep -E '^DB Schema.*[0-9]+$'"
-    - names:
-      {% for user, option in librenms.config.users.items() %}
-      - php adduser.php {{ user }} {{ option.password }} {{ option.level }} {{ option.email }}
-      {% endfor %}
+    - unless: mysql --user="{{ librenms.config.db.user }}" --database="{{ librenms.config.db.database }}" --password="{{ librenms.config.db.password }}" --execute="SELECT * FROM users WHERE username = '{{ user }}'" | grep "{{ user }}"
     - require:
       - file: librenms_config
+{% endfor %}

--- a/librenms/users.sls
+++ b/librenms/users.sls
@@ -8,7 +8,7 @@ librenms_webuser_{{ user}}:
   cmd.run:
     - name: php adduser.php "{{ user }}" "{{ option.password }}" "{{ option.level }}" "{{ option.email }}"
     - cwd: {{ librenms.general.home }}
-    - onlyif: "php {{ librenms.general.home }}/validate.php | grep -E '^DB Schema.*[0-9]+$'"
+    - onlyif: "php {{ librenms.general.home }}/validate.php | grep -E '^DB Schema.*[1-9][0-9]+$'"
     - unless: mysql --user="{{ librenms.config.db.user }}" --database="{{ librenms.config.db.database }}" --password="{{ librenms.config.db.password }}" --execute="SELECT * FROM users WHERE username = '{{ user }}'" | grep "{{ user }}"
     - require:
       - file: librenms_config

--- a/librenms/users.sls
+++ b/librenms/users.sls
@@ -6,7 +6,7 @@ include:
 librenms_webusers:
   cmd.run:
     - cwd: {{ librenms.general.home }}
-    - onlyif: "php validate.php | grep -E '^DB Schema: [0-9]+$'"
+    - onlyif: "php {{ librenms.general.home }}/validate.php | grep -E '^DB Schema.*[0-9]+$'"
     - names:
       {% for user, option in librenms.config.users.items() %}
       - php adduser.php {{ user }} {{ option.password }} {{ option.level }} {{ option.email }}

--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,7 @@
 librenms:
+  # branch, tag or commit you want to use
+  # defaults to 'master'
+  revision: master
   config:
     db:
       extension: mysqli

--- a/pillar.example
+++ b/pillar.example
@@ -23,6 +23,19 @@ librenms:
         level: '10'
         email: 'randomuser@example.com'
 
+    # This should *only* be set if you want to *force* a particular hostname/port
+    # It will prevent the web interface being usable form any other hostname
+
+    base_url: https://example.com
+    # https://github.com/librenms/librenms/blob/master/doc/Extensions/Sub-Directory.md
+    # In order to maintain upgradablility, we create a custom htaccess file
+    # which you need to include into your Apache config:
+    #
+    # <Directory /opt/librenms/html>
+    #  Include /opt/librenms/html/plugins/custom-htaccess.conf
+    # </Directory>
+    base_path: "/librenms/"
+
     custom_options:
       - "$config['oxidized']['enabled']         = TRUE;"
       - "$config['oxidized']['url']             = 'http://127.0.0.1:8888';"


### PR DESCRIPTION
### FreeBSD

  - added package names
  - cronjobs (FreeBSD has no `/etc/cron.d`.)

### Fixes
  - composer install on git update
  - build-base: fixed unless cmd
  - users: fixed onlyif cmd
  - map.jinja: added missing pkgs to Debian
  - Add webserver user to librenms group
  - run build-base cmd as librenms user
  - prevent ongoning updates (make blue states green)
    - Fixed permissions update cycle
    - Detect whether web user already exists

### Feature: use a base path (`/librenms/`)
  - Set and configure (rewrite) base path

Tested on FreeBSD 10.3.
